### PR TITLE
Lock version of plugin-data-transform

### DIFF
--- a/pattern-lab/composer.json
+++ b/pattern-lab/composer.json
@@ -33,7 +33,7 @@
         "pattern-lab/drupal-twig-components": "^0.1.1"
     },
     "require-dev": {
-        "aleksip/plugin-data-transform": "dev-master"
+        "aleksip/plugin-data-transform": "0.10.1"
     },
     "scripts": {
         "post-create-project-cmd": [


### PR DESCRIPTION
Resolves #3 .

Lock `aleksip/plugin-data-transform` to `0.10.1` as per https://github.com/phase2/drupal-lab/commit/d981d99bad17741c95922a747580db070c3ff2af